### PR TITLE
Feat/reboot

### DIFF
--- a/companion/HELP.md
+++ b/companion/HELP.md
@@ -12,6 +12,7 @@
 - Enable/Disable Scheduler and configure scheduler actions
 - Rename file
 - Rename file with current timestamp - YYYYMMDD_HHMM
+- Reboot system
 
 Check out the [AJA HELO Support Page](https://www.aja.com/products/helo#support) for firmware updates and hardware support.
 

--- a/src/actions.js
+++ b/src/actions.js
@@ -198,7 +198,7 @@ module.exports = {
 
 		actions.reboot = {
 			name: 'Reboot System',
-			description: 'Reboot the HELO using the most recent firmware image',
+			description: 'Reboot the HELO using the most recent firmware image. The device may report errors while it is non-responsive during reboot.',
 			options: [],
 			callback: async (event) => {
 				const result = await self.connection.sendRequest(

--- a/src/actions.js
+++ b/src/actions.js
@@ -196,6 +196,25 @@ module.exports = {
 			},
 		}
 
+		actions.reboot = {
+			name: 'Reboot System',
+			description: 'Reboot the HELO using the most recent firmware image',
+			options: [],
+			callback: async (event) => {
+				const result = await self.connection.sendRequest(
+					'action=set&paramid=eParamID_Reboot&value=1&configid=0'
+				)
+				self.log('debug', 'action call: Reboot result: ' + JSON.stringify(result))
+
+				if (result.status === 'success') {
+					self.updateStatus(InstanceStatus.Connecting, 'Reboot command sent')
+				} else {
+					self.log('warn', 'Reboot command did not return cleanly; the HELO may already be rebooting')
+					self.updateStatus(InstanceStatus.Connecting, 'Reboot command sent; waiting for device')
+				}
+			},
+		}
+
 		if (self.config.model == 'classic' || self.config.model == undefined) {
 			actions.setProfile = {
 				name: 'Choose Profiles',

--- a/src/actions.js
+++ b/src/actions.js
@@ -198,7 +198,7 @@ module.exports = {
 
 		actions.reboot = {
 			name: 'Reboot System',
-			description: 'Reboot the HELO using the most recent firmware image. The device may report errors while it is non-responsive during reboot.',
+			description: 'Reboot the HELO. The device may report errors while it is non-responsive during reboot.',
 			options: [],
 			callback: async (event) => {
 				const result = await self.connection.sendRequest(

--- a/src/polling.js
+++ b/src/polling.js
@@ -156,6 +156,7 @@ module.exports = {
 
 				self.checkVariables()
 				self.checkFeedbacks()
+				self.updateStatus(InstanceStatus.Ok)
 			}, self.config.polling_rate)
 		}
 	},

--- a/testing/mock_helo.py
+++ b/testing/mock_helo.py
@@ -26,6 +26,7 @@ state = {
     "eParamID_DelayAudioMs": 0,
     "eParamID_AnalogAudioInputLevel": 0,
     "eParamID_BeerGoggles": 0,
+    "eParamID_Reboot": 0,
 }
 
 state = {


### PR DESCRIPTION
This pull request introduces a new system reboot action to the HELO Companion module and makes supporting updates to documentation, polling status, and the testing mock. The main goal is to allow users to trigger a device reboot directly from the Companion interface.

**New Feature: System Reboot**

* Added a new `reboot` action in `src/actions.js` that sends a reboot command to the HELO device, handles response logging, and updates the module status accordingly.

<img width="523" height="239" alt="image" src="https://github.com/user-attachments/assets/6ae07b25-2692-47e0-af63-8ae8f0f51f22" />

* Updated `HELP.md` to document the new reboot system action.

**Supporting Changes**

* Added `eParamID_Reboot` to the mock HELO device in `testing/mock_helo.py` to support testing the reboot action.
 Ensured that the polling loop in `src/polling.js` sets the instance status to OK after each poll, improving status accuracy.

**Tested on...**
* HELO Plus with firmware version 2.1.5.5-31r _(latest available for this device)_
  * Also tested on firmware version 2.1.3.0-16r
* HELO with firmware version 4.3.0.8-12r _(latest available for this device)_
